### PR TITLE
chore: upgrade web-token/jwt-framework 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "symfony/config": "^4.3|~5.0|~6.0",
     "symfony/dependency-injection": "^4.4|~5.0|~6.0",
     "sensio/framework-extra-bundle": "~3.0|~4.0|~5.0|~6.0",
-    "web-token/jwt-framework": "^2.2"
+    "web-token/jwt-framework": "^3.4"
   }
   ,
   "require-dev": {

--- a/src/JWTService.php
+++ b/src/JWTService.php
@@ -4,10 +4,19 @@ namespace Toyokumo\JWTBundle;
 
 use Exception;
 use InvalidArgumentException;
+use Jose\Component\Checker\AlgorithmChecker;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Checker\ExpirationTimeChecker;
+use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Checker\IssuedAtChecker;
+use Jose\Component\Checker\NotBeforeChecker;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\Util\JsonConverter;
 use Jose\Component\Signature\Algorithm\HS256;
 use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\JWSTokenSupport;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Toyokumo\JWTBundle\Exception\InvalidJWTException;
 use Toyokumo\JWTBundle\Exception\NotVerifiedJWTException;
 use Jose\Component\Checker\InvalidClaimException;
@@ -15,7 +24,6 @@ use Jose\Component\Checker\InvalidHeaderException;
 use Jose\Component\Core\JWKSet;
 use Jose\Component\KeyManagement\JWKFactory;
 use Jose\Component\Signature\Serializer\CompactSerializer;
-use Jose\Easy\Load;
 
 /**
  * Class JWTService
@@ -28,6 +36,14 @@ class JWTService
     private JWSBuilder $jwsBuilder;
 
     private CompactSerializer $compactSerializer;
+
+    private JWSVerifier $jwsVerifier;
+
+    private JWSSerializerManager $serializerManager;
+
+    private HeaderCheckerManager $headerCheckerManager;
+
+    private ClaimCheckerManager $claimCheckerManager;
 
     /**
      * JWTService constructor.
@@ -69,6 +85,29 @@ class JWTService
             new HS256()
         ]));
         $this->compactSerializer = new CompactSerializer();
+        $this->jwsVerifier = new JWSVerifier(new AlgorithmManager([
+            new HS256()
+        ]));
+        $this->serializerManager = new JWSSerializerManager([
+            new CompactSerializer()
+        ]);
+        // https://web-token.spomky-labs.com/the-components/header-checker#header-checker-manager
+        $this->headerCheckerManager = new HeaderCheckerManager([
+            new AlgorithmChecker(['HS256']),
+            // We want to verify that the header "alg" (algorithm)
+            // is present and contains "HS256"
+        ],
+            [
+                new JWSTokenSupport(), // Adds JWS token type support
+            ]);
+        // https://web-token.spomky-labs.com/the-components/claim-checker#claim-checker-manager
+        $this->claimCheckerManager = new ClaimCheckerManager(
+            [
+                new IssuedAtChecker(),
+                new NotBeforeChecker(),
+                new ExpirationTimeChecker(),
+            ]
+        );
     }
 
     /**
@@ -111,39 +150,29 @@ class JWTService
     public function extractValueFromToken(string $token, string $claimKey)
     {
         try {
-            // Get kid for identifying jwk
-            $signatures = (new CompactSerializer())
-                ->unserialize($token)
-                ->getSignatures();
+            $jws = $this->serializerManager->unserialize($token);
+            // header validation
+            $this->headerCheckerManager->check($jws, 0, ['alg', 'kid']);
+            // payload validation
+            $claims = JsonConverter::decode($jws->getPayload());
+            $this->claimCheckerManager->check($claims);
+            // signature validation
+            $signatures = $jws->getSignatures();
             $signature = $signatures[0];
-            if (!$signature->hasProtectedHeaderParameter('kid')) {
-                throw new NotVerifiedJWTException('Token is not verified.');
-            }
             $kid = $signature->getProtectedHeaderParameter('kid');
-            if (!$this->jwkSet->has($kid)) {
-                throw new NotVerifiedJWTException('Token is not verified.');
-            }
             $jwk = $this->jwkSet->get($kid);
-
-            $jwt = Load::jws($token)
-                ->alg($jwk->get('alg'))
-                ->exp()
-                ->nbf()
-                ->key($jwk)
-                ->run();
-        } catch (InvalidClaimException $e) {
-            // token expiration etc..
-            throw new InvalidJWTException('Token is invalid.');
-        } catch (InvalidHeaderException $e) {
-            // alg=none tampering etc..
-            throw new NotVerifiedJWTException('Token is not verified.');
-        } catch (InvalidArgumentException $e) {
-            if ($e->getMessage() === 'Unsupported input') {
-                // failed to decode token
+            $isVerified = $this->jwsVerifier->verifyWithKey($jws, $jwk, 0);
+            if (!$isVerified) {
                 throw new NotVerifiedJWTException('Token is not verified.');
             }
-            if ($e->getMessage() === 'Undefined index') {
-                // there is no JWK corresponding to kid
+        } catch (InvalidArgumentException $e) {
+            // 表記揺れがあるので str_contains で対応
+            if (str_contains($e->getMessage(), 'Unsupported input')) {
+                throw new NotVerifiedJWTException('Token is not verified.');
+            }
+
+            // 表記揺れがあるので str_contains で対応
+            if (str_contains($e->getMessage(), 'Undefined index')) {
                 throw new NotVerifiedJWTException('Token is not verified.');
             }
             throw $e;
@@ -154,6 +183,6 @@ class JWTService
             throw $e;
         }
 
-        return $jwt->claims->get($claimKey);
+        return $claims[$claimKey];
     }
 }

--- a/tests/JWTServiceTest.php
+++ b/tests/JWTServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Toyokumo\JWTBundle;
 
+use Jose\Component\Checker\InvalidClaimException;
 use PHPUnit\Framework\TestCase;
 use Toyokumo\JWTBundle\Exception\InvalidJWTException;
 use Toyokumo\JWTBundle\Exception\NotVerifiedJWTException;
@@ -49,7 +50,7 @@ class JWTServiceTest extends TestCase
     {
         $token = $this->jwt->generateJWSToken(['hoge' => 'fuga'], 'test_key', -1); // exp = -1 means expire right now
 
-        $this->expectException(InvalidJWTException::class);
+        $this->expectException(InvalidClaimException::class);
         $this->jwt->extractValueFromToken($token, 'hoge');
     }
 


### PR DESCRIPTION
By updating web-token/jwt-framework to 3 series, it will be compatible with symfony 6 series.

https://web-token.spomky-labs.com/migration/from-v1.x-to-v2.0-1#list-of-deprecations
