### PR TITLE
refactor: remove unused dependency sensio/framework-extra-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "php": "^7.4|^8.0",
     "symfony/config": "^4.3|~5.0|~6.0",
     "symfony/dependency-injection": "^4.4|~5.0|~6.0",
-    "sensio/framework-extra-bundle": "~3.0|~4.0|~5.0|~6.0",
     "web-token/jwt-framework": "^3.4"
   }
   ,


### PR DESCRIPTION
以下理由から sensio/framework-extra-bundle 依存を削除したいです

- 利用していない
- sensio/framework-extra-bundle は public archive になっていて更新がない
- このパッケージを使っている製品で sensio/framework-extra-bundle の依存を削除できない

念のためリポジトリ内で Sensio で grep しましたが hit しないことを確認しました